### PR TITLE
Invoice items associated with item

### DIFF
--- a/app/controllers/api/v1/items/invoice_items_controller.rb
+++ b/app/controllers/api/v1/items/invoice_items_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Items::InvoiceItemsController < ApplicationController
+  def index
+    item = Item.find(params[:id])
+    invoice_items = item.invoice_items
+    serialized = InvoiceItemSerializer.new(invoice_items)
+    render json: serialized
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,11 +6,16 @@ Rails.application.routes.draw do
         get ':id/invoices', to: 'invoices#index'
         get ':id/transactions', to: 'transactions#index'
       end
+
       namespace :merchants do
         get ':id/items', to: 'items#index'
         get ':id/invoices', to: 'invoices#index'
       end
 
+      namespace :items do
+        get ':id/invoice_items', to: 'invoice_items#index'
+      end
+      
       resources :customers, only: [:index, :show]
 
       resources :merchants, only: [:index, :show]

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -28,4 +28,26 @@ describe "items API" do
     expect(response).to be_successful
     expect(item["data"]["id"]).to eq("#{id}")
   end
+
+  it "sends a collection of invoice items associated with one item" do
+    customer = create(:customer)
+    merchant = create(:merchant)
+    invoice = customer.invoices.create(merchant: merchant)
+    item_1 = merchant.items.create
+    item_2 = merchant.items.create
+    invoice_item_1 = item_1.invoice_items.create(invoice: invoice)
+    invoice_item_2 = item_1.invoice_items.create(invoice: invoice)
+    invoice_item_3 = item_2.invoice_items.create(invoice: invoice)
+
+    get "/api/v1/items/#{item_1.id}/invoice_items"
+
+    expect(response).to be_successful
+
+    invoice_items = JSON.parse(response.body)
+
+    expect(invoice_items["data"].length).to eq(2)
+    expect(invoice_items["data"][0]["attributes"]["id"]).to eq(invoice_item_1.id)
+    expect(invoice_items["data"][1]["attributes"]["id"]).to eq(invoice_item_2.id)
+    expect(invoice_items["data"][2]).to be_nil
+  end
 end


### PR DESCRIPTION
* Add test that it can send a collection of invoice items associated with one item
* Add route to send invoice items associated with one item
* Add Items::InvoiceItemsController with index method
* Associated rake test passing